### PR TITLE
Add support for a custom tag prefix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,12 @@ inputs:
   branch:
     description: Reject releases from commits not contained in branches that match the specified pattern (regular expression)
     required: false
+  prefix:
+    description: >
+      A prefix for the release tag, before the version number (for
+      example, 'my-crate-v0.1.2' has the prefix 'my-crate-').
+    required: false
+    default: ''
 
 runs:
   using: node12

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: GitHub Action for creating GitHub Releases based on changelog
 
 inputs:
   changelog:
-    description: Path to changelog
+    description: Path to changelog (variables `$tag`, `$version`, `$prefix`, and any string)
     required: false
   title:
     description: Format of title (variables `$tag`, `$version`, `$prefix`, and any string)
@@ -18,15 +18,22 @@ inputs:
     required: false
   prefix:
     description: >
-      A prefix for the release tag, before the version number (for
-      example, 'my-crate-v0.1.2' has the prefix 'my-crate-').
+      An optional pattern that matches a prefix for the release tag, before the
+      version number.
 
-      The prefix may not contain regular expression characters such as `\`, `.`,
-      `(`, `)`, `[`, `]`, `{` and `}`.
+      If a prefix is provided, an optional '-' character is permitted (but not
+      required) between the prefix and the version number.   For example, the
+      tags 'my-crate-v0.1.2' and 'my-crate0.1.0' both have the prefix 'my-crate'.
 
-      If the prefix ends in a trailing '-', it will be stripped before
-      interpolating the prefix into the title, if `$prefix` appears in the title
-      format.
+      This is interpreted as a bash-style regular expression, so it may be used
+      to match multiple prefix strings. Therefore, literal characters that
+      are part of bash's regular expression syntax, such as `$`, `^`, `[`, `]`,
+      `{`, `}`, `(`, `)`, and `|` must be escaped if they occur in the prefix
+      pattern.
+
+      If a prefix pattern is provided, the portion of the tag that matched the
+      prefix can be interpolated into `title` and `changelog` via the `$prefix`
+      variable.
     required: false
     default: ''
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
     description: >
       A prefix for the release tag, before the version number (for
       example, 'my-crate-v0.1.2' has the prefix 'my-crate-').
+
+      The prefix may not contain regular expression characters such as `\`, `.`,
+      `(`, `)`, `[`, `]`, `{` and `}`.
     required: false
     default: ''
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Path to changelog
     required: false
   title:
-    description: Format of title (variables `$tag`, `$version`, and any string)
+    description: Format of title (variables `$tag`, `$version`, `$prefix`, and any string)
     required: false
     default: '$tag'
   draft:
@@ -23,6 +23,10 @@ inputs:
 
       The prefix may not contain regular expression characters such as `\`, `.`,
       `(`, `)`, `[`, `]`, `{` and `}`.
+
+      If the prefix ends in a trailing '-', it will be stripped before
+      interpolating the prefix into the title, if `$prefix` appears in the title
+      format.
     required: false
     default: ''
 

--- a/main.sh
+++ b/main.sh
@@ -19,10 +19,6 @@ draft="${INPUT_DRAFT:-}"
 branch="${INPUT_BRANCH:-}"
 prefix="${INPUT_PREFIX:-}"
 
-# `prefix` is used as part of a regular expression, but it's a literal string,
-# so escape any regex special characters first
-prefix="$(printf '%s' "$prefix" | sed 's/[]\\.$*{}|+?()[^-]/\\&/g')"
-
 if [[ -z "${GITHUB_TOKEN:-}" ]]; then
     error "GITHUB_TOKEN not set"
     exit 1
@@ -33,6 +29,11 @@ if [[ "${GITHUB_REF:?}" != "refs/tags/"* ]]; then
     exit 1
 fi
 tag="${GITHUB_REF#refs/tags/}"
+
+if [[ "${prefix}" =~ (\\|\$|\[|\]|\*|\||\{|\}|\+|\?|\^|\(|\)|\.)+ ]]; then
+    error "prefix '${prefix}' contained regular expression characters"
+    exit 1
+fi
 
 if [[ ! "${tag}" =~ ^${prefix}v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z_0-9\.-]+)?(\+[a-zA-Z_0-9\.-]+)?$ ]]; then
     error "invalid tag format: '${tag}'"

--- a/main.sh
+++ b/main.sh
@@ -30,7 +30,6 @@ if [[ "${GITHUB_REF:?}" != "refs/tags/"* ]]; then
 fi
 tag="${GITHUB_REF#refs/tags/}"
 
-
 if [[ ! "${tag}" =~ ^${prefix}-?v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z_0-9\.-]+)?(\+[a-zA-Z_0-9\.-]+)?$ ]]; then
     error "invalid tag format: '${tag}'"
     exit 1

--- a/main.sh
+++ b/main.sh
@@ -41,7 +41,7 @@ fi
 version="${tag}"
 # extract the portion of the tag matching the prefix pattern
 if [[ ! "${prefix}" = "" ]]; then
-    prefix=$(expr match "${tag}" "\(${prefix}\)")
+    prefix=$(grep <<<"${tag}" -Eo "^${prefix}")
     version="${tag#${prefix}}"
     version="${version#-}"
 fi

--- a/main.sh
+++ b/main.sh
@@ -43,8 +43,13 @@ if [[ "${tag}" =~ ^${prefix}v?[0-9\.]+-[a-zA-Z_0-9\.-]+(\+[a-zA-Z_0-9\.-]+)?$ ]]
     prerelease="--prerelease"
 fi
 version="${tag#${prefix}v}"
+# if the prefix has a trailing slash, strip it so that the prefix can be used in
+# the title.
+prefix="${prefix#-}"
 title="${title/\$tag/${tag}}"
 title="${title/\$version/${version}}"
+title="${title/\$prefix/${prefix}}"
+
 
 case "${draft}" in
     true) draft_option="--draft" ;;

--- a/main.sh
+++ b/main.sh
@@ -42,7 +42,7 @@ version="${tag}"
 # extract the portion of the tag matching the prefix pattern
 if [[ ! "${prefix}" = "" ]]; then
     prefix=$(grep <<<"${tag}" -Eo "^${prefix}")
-    version="${tag#${prefix}}"
+    version="${tag#"${prefix}"}"
     version="${version#-}"
 fi
 version="${version#v}"


### PR DESCRIPTION
This branch adds support for specifiying a tag prefix before the version
number. The prefix is specified as a bash regular expression; the string
matching that regular expression is available in the `$prefix` variable
that can be interpolated into the `changelog` path and `title` string.

Additionally, since I was adding support for interpolating `$prefix`
into the changelog path anyway, I went ahead and allowed `$version` and
`$tag` to be interpolated into the changelog path as well. This _might_
be useful in cases where the changelog for each version is stored in its
own text file...though I don't think this is a particularly common
pattern.

Closes #1