### PR TITLE
Remove trailing hyphen from prefix

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -43,6 +43,7 @@ version="${tag}"
 # extract the portion of the tag matching the prefix pattern
 if [[ ! "${prefix}" = "" ]]; then
     prefix=$(grep <<<"${tag}" -Eo "^${prefix}")
+    prefix="${prefix%-}"
     version="${tag#"${prefix}"}"
     version="${version#-}"
 fi


### PR DESCRIPTION
Currently, if INPUT_PREFIX is `tracing[a-z-]*` and tag is `tracing-subscriber-0.3.4`, `$prefix` is `tracing-subscriber-`, because trailing hyphen is included in INPUT_PREFIX's pattern.


fyi @hawkw 