### PR TITLE
Add `token` and `ref` input options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `token` input option to use the specified token instead of `GITHUB_TOKEN` environment variable.
+
 - Update `parse-changelog` to 0.5.1. This includes a bug fix and performance improvements.
 
 ## [1.5.0] - 2022-02-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 - Add `token` input option to use the specified token instead of `GITHUB_TOKEN` environment variable.
 
+- Add `ref` input option to use the specified tag ref instead of `GITHUB_REF` environment variable.
+
 - Update `parse-changelog` to 0.5.1. This includes a bug fix and performance improvements.
 
 ## [1.5.0] - 2022-02-17

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Currently, changelog format and supported tag names have the following rule:
 | draft     | false     | Create a draft release (`true` or `false`)                                  | Boolean | `false` |
 | branch    | false     | Reject releases from commits not contained in branches that match the specified pattern (regular expression) | String  |         |
 | prefix    | false     | An optional pattern that matches a prefix for the release tag, before the version number (see [action.yml](action.yml) for more) | String |         |
+| ref       | false     | Fully-formed tag ref for this release (see [action.yml](action.yml) for more) | String |         |
 
 [^1]: Required one of `token` input option or `GITHUB_TOKEN` environment variable.
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,16 @@ Currently, changelog format and supported tag names have the following rule:
 
 ### Inputs
 
-| Name      | Required | Description                                                                 | Type    | Default |
-|-----------|:--------:|-----------------------------------------------------------------------------|---------|---------|
-| changelog | false    | Path to changelog (variables `$tag`, `$version`, `$prefix`, and any string) | String  |         |
-| title     | false    | Format of title (variables `$tag`, `$version`, `$prefix`, and any string)   | String  | `$tag`  |
-| draft     | false    | Create a draft release (`true` or `false`)                                  | Boolean | `false` |
-| branch    | false    | Reject releases from commits not contained in branches that match the specified pattern (regular expression) | String  |         |
-| prefix    | false    | An optional pattern that matches a prefix for the release tag, before the version number (see [action.yml](action.yml) for more) | String |         |
+| Name      | Required  | Description                                                                 | Type    | Default |
+|-----------|:---------:|-----------------------------------------------------------------------------|---------|---------|
+| token     | false [^1]| GitHub token for creating GitHub Releases (see [action.yml](action.yml) for more) | String |         |
+| changelog | false     | Path to changelog (variables `$tag`, `$version`, `$prefix`, and any string) | String  |         |
+| title     | false     | Format of title (variables `$tag`, `$version`, `$prefix`, and any string)   | String  | `$tag`  |
+| draft     | false     | Create a draft release (`true` or `false`)                                  | Boolean | `false` |
+| branch    | false     | Reject releases from commits not contained in branches that match the specified pattern (regular expression) | String  |         |
+| prefix    | false     | An optional pattern that matches a prefix for the release tag, before the version number (see [action.yml](action.yml) for more) | String |         |
+
+[^1]: Required one of `token` input option or `GITHUB_TOKEN` environment variable.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ Currently, changelog format and supported tag names have the following rule:
 
 ### Inputs
 
-| Name      | Required  | Description                                                                 | Type    | Default |
-|-----------|:---------:|-----------------------------------------------------------------------------|---------|---------|
-| token     | false [^1]| GitHub token for creating GitHub Releases (see [action.yml](action.yml) for more) | String |         |
-| changelog | false     | Path to changelog (variables `$tag`, `$version`, `$prefix`, and any string) | String  |         |
-| title     | false     | Format of title (variables `$tag`, `$version`, `$prefix`, and any string)   | String  | `$tag`  |
-| draft     | false     | Create a draft release (`true` or `false`)                                  | Boolean | `false` |
-| branch    | false     | Reject releases from commits not contained in branches that match the specified pattern (regular expression) | String  |         |
-| prefix    | false     | An optional pattern that matches a prefix for the release tag, before the version number (see [action.yml](action.yml) for more) | String |         |
-| ref       | false     | Fully-formed tag ref for this release (see [action.yml](action.yml) for more) | String |         |
+| Name      | Required     | Description                                                                 | Type    | Default |
+|-----------|:------------:|-----------------------------------------------------------------------------|---------|---------|
+| token     | **true** [^1]| GitHub token for creating GitHub Releases (see [action.yml](action.yml) for more) | String |         |
+| changelog | false        | Path to changelog (variables `$tag`, `$version`, `$prefix`, and any string) | String  |         |
+| title     | false        | Format of title (variables `$tag`, `$version`, `$prefix`, and any string)   | String  | `$tag`  |
+| draft     | false        | Create a draft release (`true` or `false`)                                  | Boolean | `false` |
+| branch    | false        | Reject releases from commits not contained in branches that match the specified pattern (regular expression) | String  |         |
+| prefix    | false        | An optional pattern that matches a prefix for the release tag, before the version number (see [action.yml](action.yml) for more) | String |         |
+| ref       | false        | Fully-formed tag ref for this release (see [action.yml](action.yml) for more) | String |         |
 
 [^1]: Required one of `token` input option or `GITHUB_TOKEN` environment variable.
 
@@ -79,9 +79,8 @@ jobs:
         with:
           # (Optional) Path to changelog.
           changelog: CHANGELOG.md
-        env:
           # (Required) GitHub token for creating GitHub Releases.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Example workflow: Create a draft release
@@ -109,9 +108,8 @@ jobs:
           # (Optional) Create a draft release.
           # [default value: false]
           draft: true
-        env:
           # (Required) GitHub token for creating GitHub Releases.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Example workflow: Custom title
@@ -144,9 +142,8 @@ jobs:
           # [default value: $tag]
           # [possible values: variables $tag, $version, and any string]
           title: $version
-        env:
           # (Required) GitHub token for creating GitHub Releases.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Example workflow: No changelog
@@ -172,9 +169,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: taiki-e/create-gh-release-action@v1
-        env:
+        with:
           # (Required) GitHub token for creating GitHub Releases.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Example workflow: Reject releases from outside of main branch
@@ -204,9 +201,8 @@ jobs:
           # (Optional) Reject releases from commits not contained in branches
           # that match the specified pattern (regular expression)
           branch: main
-        env:
           # (Required) GitHub token for creating GitHub Releases.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Other examples

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,12 @@ inputs:
       variable.
     required: false
     default: ''
+  token:
+    description: >
+      GitHub token for creating GitHub Releases.
+
+      If not set this option, the GITHUB_TOKEN environment variable will be used.
+    required: false
 
 outputs:
   computed-prefix:

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,12 @@ inputs:
 
       If not set this option, the GITHUB_TOKEN environment variable will be used.
     required: false
+  ref:
+    description: >
+      Fully-formed tag ref for this release.
+
+      If not set this option, the GITHUB_REF environment variable (automatically set by GitHub Actions) will be used.
+    required: false
 
 outputs:
   computed-prefix:

--- a/main.sh
+++ b/main.sh
@@ -23,15 +23,16 @@ draft="${INPUT_DRAFT:-}"
 branch="${INPUT_BRANCH:-}"
 prefix="${INPUT_PREFIX:-}"
 token="${INPUT_TOKEN:-"${GITHUB_TOKEN:-}"}"
+ref="${INPUT_REF:-"${GITHUB_REF:-}"}"
 
 if [[ -z "${token:-}" ]]; then
     bail "neither GITHUB_TOKEN environment variable nor 'token' input option is set."
 fi
 
-if [[ "${GITHUB_REF:?}" != "refs/tags/"* ]]; then
-    bail "this action can only be used on 'push' event for 'tags' (GITHUB_REF should start with 'refs/tags/': '${GITHUB_REF}')"
+if [[ "${ref:?}" != "refs/tags/"* ]]; then
+    bail "tag ref should start with 'refs/tags/': '${ref}'"
 fi
-tag="${GITHUB_REF#refs/tags/}"
+tag="${ref#refs/tags/}"
 
 release_options=("${tag}")
 parse_changelog_options=()

--- a/main.sh
+++ b/main.sh
@@ -22,9 +22,10 @@ changelog="${INPUT_CHANGELOG:-}"
 draft="${INPUT_DRAFT:-}"
 branch="${INPUT_BRANCH:-}"
 prefix="${INPUT_PREFIX:-}"
+token="${INPUT_TOKEN:-"${GITHUB_TOKEN:-}"}"
 
-if [[ -z "${GITHUB_TOKEN:-}" ]]; then
-    bail "GITHUB_TOKEN not set"
+if [[ -z "${token:-}" ]]; then
+    bail "neither GITHUB_TOKEN environment variable nor 'token' input option is set."
 fi
 
 if [[ "${GITHUB_REF:?}" != "refs/tags/"* ]]; then
@@ -103,13 +104,13 @@ if [[ -n "${changelog}" ]]; then
 fi
 
 # https://cli.github.com/manual/gh_release_view
-if gh release view "${tag}" &>/dev/null; then
+if GITHUB_TOKEN="${token}" gh release view "${tag}" &>/dev/null; then
     # https://cli.github.com/manual/gh_release_delete
-    gh release delete "${tag}" -y
+    GITHUB_TOKEN="${token}" gh release delete "${tag}" -y
 fi
 
 # https://cli.github.com/manual/gh_release_create
-gh release create "${release_options[@]}" --title "${title}" --notes "${notes:-}"
+GITHUB_TOKEN="${token}" gh release create "${release_options[@]}" --title "${title}" --notes "${notes:-}"
 
 # set (computed) prefix and version outputs for future step use
 computed_prefix=${tag%"${version}"}


### PR DESCRIPTION
- Add `token` input option to use the specified token instead of `GITHUB_TOKEN` environment variable.
- Add `ref` input option to use the specified tag ref instead of `GITHUB_REF` environment variable.

Option names are from actions/checkout.

Closes #14
Partially replaces #15