### PR TITLE
Added new input `allow_missing_changelog:boolean`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+### Added
+
+- Added new input `allowMissingChangelog:boolean` that will allow the build to continue to run even though the targeted version was not found on the changelog file.  The default of this input is `false` to stay backwards compatible.
+
 ## [1.6.3] - 2023-03-19
 
 - Diagnostics improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ### Added
 
-- Added new input `allowMissingChangelog:boolean` that will allow the build to continue to run even though the targeted version was not found on the changelog file.  The default of this input is `false` to stay backwards compatible.
+- Added new input `allow_missing_changelog:boolean` that will allow the build to continue to run even though the targeted version was not found on the changelog file.  The default of this input is `false` to stay backwards compatible.
 
 ## [1.6.3] - 2023-03-19
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Currently, changelog format and supported tag names have the following rule:
 |-----------|:------------:|-----------------------------------------------------------------------------|---------|---------|
 | token     | **true** [^1]| GitHub token for creating GitHub Releases (see [action.yml](action.yml) for more) | String |         |
 | changelog | false        | Path to changelog (variables `$tag`, `$version`, `$prefix`, and any string) | String  |         |
-| allowMissingChangelog | false | Allows for the build to continue even if the version is not found in the changelog. The default value of the changelog will be an empty string. | Boolean | `false` |
+| allow_missing_changelog | false | Allows for the build to continue even if the version is not found in the changelog. The default value of the changelog will be an empty string. | Boolean | `false` |
 | title     | false        | Format of title (variables `$tag`, `$version`, `$prefix`, and any string)   | String  | `$tag`  |
 | draft     | false        | Create a draft release (`true` or `false`)                                  | Boolean | `false` |
 | branch    | false        | Reject releases from commits not contained in branches that match the specified pattern (regular expression) | String  |         |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Currently, changelog format and supported tag names have the following rule:
 |-----------|:------------:|-----------------------------------------------------------------------------|---------|---------|
 | token     | **true** [^1]| GitHub token for creating GitHub Releases (see [action.yml](action.yml) for more) | String |         |
 | changelog | false        | Path to changelog (variables `$tag`, `$version`, `$prefix`, and any string) | String  |         |
+| allowMissingChangelog | false | Allows for the build to continue even if the version is not found in the changelog. The default value of the changelog will be an empty string. | Boolean | `false` |
 | title     | false        | Format of title (variables `$tag`, `$version`, `$prefix`, and any string)   | String  | `$tag`  |
 | draft     | false        | Create a draft release (`true` or `false`)                                  | Boolean | `false` |
 | branch    | false        | Reject releases from commits not contained in branches that match the specified pattern (regular expression) | String  |         |

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,13 @@ inputs:
   changelog:
     description: Path to changelog (variables `$tag`, `$version`, `$prefix`, and any string)
     required: false
+  allowMissingChangelog:
+    description: >
+      If true, it will create the GitHub release with an empty notes for the changelog if the changelog.md file does not
+      have the appropriate version in it.  By default, this action will fail if the version tagged is not found in the
+      changelog file.
+    required: false
+    default: false
   title:
     description: Format of title (variables `$tag`, `$version`, `$prefix`, and any string)
     required: false

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   changelog:
     description: Path to changelog (variables `$tag`, `$version`, `$prefix`, and any string)
     required: false
-  allowMissingChangelog:
+  allow_missing_changelog:
     description: >
       If true, it will create the GitHub release with an empty notes for the changelog if the changelog.md file does not
       have the appropriate version in it.  By default, this action will fail if the version tagged is not found in the

--- a/main.sh
+++ b/main.sh
@@ -110,7 +110,14 @@ if [[ -n "${changelog}" ]]; then
     retry curl --proto '=https' --tlsv1.2 -fsSL --retry 10 --retry-connrefused "https://github.com/taiki-e/parse-changelog/releases/download/v${parse_changelog_version}/parse-changelog-${parse_changelog_target}.tar.gz" \
         | "${tar}" xzf -
     parse_changelog_options+=("${changelog}" "${version}")
-    notes=$(./parse-changelog "${parse_changelog_options[@]}")
+
+    # If allowMissingChangelog is true then default to empty value if version not found
+    if [[ "${allowMissingChangelog}" == "true" ]]; then
+        notes=$(./parse-changelog "${parse_changelog_options[@]}" || echo "")
+    else
+        notes=$(./parse-changelog "${parse_changelog_options[@]}")
+    fi
+
     rm -f ./parse-changelog
 fi
 

--- a/main.sh
+++ b/main.sh
@@ -111,8 +111,8 @@ if [[ -n "${changelog}" ]]; then
         | "${tar}" xzf -
     parse_changelog_options+=("${changelog}" "${version}")
 
-    # If allowMissingChangelog is true then default to empty value if version not found
-    if [[ "${allowMissingChangelog}" == "true" ]]; then
+    # If allow_missing_changelog is true then default to empty value if version not found
+    if [[ "${INPUT_ALLOW_MISSING_CHANGELOG}" == "true" ]]; then
         notes=$(./parse-changelog "${parse_changelog_options[@]}" || echo "")
     else
         notes=$(./parse-changelog "${parse_changelog_options[@]}")


### PR DESCRIPTION
- Added new input `allowMissingChangelog:boolean` that will allow the build to continue to run even though the targeted version was not found on the changelog file. The default of this input is `false` to stay backward compatible.

Closes #22